### PR TITLE
Allow padring to use hierarchical instances (XXX/YYYY)

### DIFF
--- a/src/configreader.cpp
+++ b/src/configreader.cpp
@@ -50,7 +50,7 @@ bool ConfigReader::isAlphaNumeric(char c) const
 
 bool ConfigReader::isSpecialIdentChar(char c) const
 {
-    if ((c == '[') || (c == ']') || (c == '<') || (c == '>'))
+    if ((c == '[') || (c == ']') || (c == '<') || (c == '>') || (c == '/'))
     {
         return true;
     }


### PR DESCRIPTION
Pad cells are not always instanciated at top level. This fix allows / in the intance name. Tested with an Openroad flow.